### PR TITLE
Extend Atom Modeling to All Backbone Atoms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ wandb/
 tmp/*
 *.fasta
 inference/*
+store/*
+*.egg-info

--- a/configs/datasets_config/afdb/d_FS.yaml
+++ b/configs/datasets_config/afdb/d_FS.yaml
@@ -3,7 +3,7 @@ datamodule:
   data_dir: ${oc.env:DATA_PATH}/d_FS/ # Directory where the dataset is stored
   in_memory: False
   format: "pdb" # Format of your data files
-  overwrite: True # Whether to overwrite existing dataset files and reprocess the raw data
+  overwrite: False # Whether to overwrite existing dataset files and reprocess the raw data
   # arguments for BaseLightningDataModule class
   batch_padding: True # whether we want a sparse PyG batch or a padded dense batch
   sampling_mode: "random" # sample randomly from the whole dataset during training

--- a/configs/experiment_config/inference_ucond_bb_60m_notri.yaml
+++ b/configs/experiment_config/inference_ucond_bb_60m_notri.yaml
@@ -1,0 +1,25 @@
+defaults:
+  - inference_base
+  - _self_
+
+run_name_: ucond_60M_bb_notri
+ckpt_path: "store/train_run_8gpu_bb_run1/checkpoints"
+ckpt_name: last-EMA.ckpt
+
+self_cond: True
+
+# Lengths to sample. Uses `nres_lens` if specified, otherwise arange(min_len, max_len+1, step)
+nres_lens: [100]
+min_len:
+max_len:
+step_len:
+
+# Number of samples per protein length
+nsamples_per_len: 5
+
+sampling_caflow:
+  sampling_mode: sc  # "vf" for ODE sampling, "sc" for SDE sampling
+  sc_scale_noise: 0.45  # noise scale, used if sampling_mode == "sc"
+
+ca_only: False
+compute_designability: False

--- a/configs/experiment_config/model/bbflow.yaml
+++ b/configs/experiment_config/model/bbflow.yaml
@@ -1,0 +1,46 @@
+name: bbflow
+
+defaults:
+  - _self_
+  - nn: bb_af3_60M_notri
+
+target_pred: v
+
+augmentation:
+  global_rotation: true  # Whether to augment samples with random rotation
+  naug_rot: 1  # How many augmentations to apply per sample (batch size increases by this factor...)
+
+validation:
+  temp_05:
+    sampling_mode: sc  # Options are: vf (plain fow matching) or sc (using score, where parameters below matter)
+    sc_scale_noise: 0.4  # scale used to multiply noise if mode == sc
+    sc_scale_score: 1.0  # scale used to multiply score if mode == sc
+    gt_mode: "1/t"  # us, tan, or 1/t
+    gt_p: 1.0  # float
+    gt_clamp_val: null  # 10.0 float or null
+  ode:
+    sampling_mode: vf
+    sc_scale_noise: 0.0
+    sc_scale_score: 0.0
+    gt_mode: "1/t"  # us, tan, or 1/t
+    gt_p: 1.0  # float
+    gt_clamp_val: null  # 10.0 float or null
+  temp_035:
+    sampling_mode: sc
+    sc_scale_noise: 0.35
+    sc_scale_score: 1.0
+    gt_mode: "1/t"  # us, tan, or 1/t
+    gt_p: 1.0  # float
+    gt_clamp_val: null  # 10.0 float or null
+
+ca_only: false
+
+# The ODE to sample flow matching is given by [dx_t = v(x_t, t) dt].
+# The SDE [dx_t = v(x_t, t) dt + g_t * s(x_t, t) dt + \sqrt(2 g_t) dw_t]
+# produces the same marginal distributions for any g_t.
+# The parameters from above are:
+#   - sampling_mode: vf or sc, corresponding to ODE or SDE
+#   - sc_scale_noise: Changes the noise term in the SDE as \sqrt(2 g_t) -> \sqrt(2 g_t * sc_scale_noise)
+#   - sc_scale_score: Changes the score term in the SDE as g_t * s(x_t, t) -> g_t * s(x_t, t) * sc_scale_score
+#   - sc_g: Sets the g_t. Specifically, we have g_t = sc_g * min(5, (1-t)/t), where the t dependency comes
+#   from the optimal transport coupling.

--- a/configs/experiment_config/model/nn/bb_af3_60M_notri.yaml
+++ b/configs/experiment_config/model/nn/bb_af3_60M_notri.yaml
@@ -1,0 +1,89 @@
+name: bb_af3  # name of architecture
+
+# Architecture parameters
+token_dim: 512  # dimension of the tokens in the sequence
+nlayers: 10  # number of transformer layers
+nheads: 8  # number of attn heads
+residual_mha: True  # whether to use a residual connection in the mha
+residual_transition: True  # whether to use a residual connection in the transition
+parallel_mha_transition: False  # whether to compute mha and transition as parallel and add them up (AF3 style) or sequentially (normal transofrmers)
+use_attn_pair_bias: True  # whether to bias attention using a bias coming from a pair representation
+
+strict_feats: False  # if False, then fills missing features with default values (e.g. chain break with zero, residue sequence index by [0, 1, 2, ...], etc)
+# If True, if some feature is not provided, then it raises an error
+
+# List of all available sequence features:
+#   "res_seq_pdb_idx", requires transform ResidueSequencePositionPdbTransform
+#   "time_emb"
+#   "chain_break_per_res", requires transform ChainBreakPerResidueTransform
+#   "x_sc"
+#   "fold_emb"
+feats_init_seq: ["chain_break_per_res", "x_sc"]  # Sequence features to include in initial representation
+feats_cond_seq: ["time_emb", "fold_emb"]  # Sequence features to include in conditioning variables
+
+
+# Parameters for the features we extract (both for sequence representatoin and conditioning vector)
+t_emb_dim: 256  # dimension of the time embedding
+dim_cond: 512  # dimension of conditioning vector
+idx_emb_dim: 128  # dimension of the sequence position [0, 1, 2, ...] (if contiguous residues) embeddings
+fold_emb_dim: 256  # dimension of fold class embedding. This will be multiplied by three, as we have C, A, T embeddings.
+cath_code_dir: ${oc.env:DATA_PATH}/pdb_raw/    # This should be set as the path to your pdb_cath dataset directory
+multilabel_mode: "sample"
+
+
+# List of all available sequence features:
+#   "xt_pair_dists"
+#   "x_sc_pair_dists"
+#   "rel_seq_sep"
+#   "time_emb"
+feats_pair_repr: ["rel_seq_sep", "x_sc_pair_dists", "xt_pair_dists"]  # Features to include in the pair representation
+feats_pair_cond: ["time_emb"]  # Features to include in the pair representation conditioning
+
+
+# Parameters for the pair features we extract
+# Binning for the pair distances of noisy xt
+xt_pair_dist_dim: 64
+xt_pair_dist_min: 0.1  # in nm (not Å)
+xt_pair_dist_max: 3  # in nm (not Å)
+# Binning for the pair distances for self conditioning
+x_sc_pair_dist_dim: 128
+x_sc_pair_dist_min: 0.1  # in nm (not Å)
+x_sc_pair_dist_max: 3  # in nm (not Å)
+# Motif Conditioning
+x_motif_pair_dist_dim: 128
+x_motif_pair_dist_min: 0.1  # in nm (not Å)
+x_motif_pair_dist_max: 3  # in nm (not Å)
+# Relative sequence separation
+seq_sep_dim: 127  # should be odd >= 5
+# Dimension of final pair representation
+pair_repr_dim: 256
+
+
+# Newer stuff for exploration
+update_pair_repr: False  # whether to update pair representation, automatically overridden to False if `use_attn_pair_bias: False`
+update_pair_repr_every_n: 2  # Update the pair representation every n layers -> For 15 layers we get 5 pair updates (if update pair represnetation is true)
+use_tri_mult: False  # whether to use triangular multiplication layers in pair update, ignored if not updating pair representation
+
+num_registers: 10
+use_qkln: True
+apply_rotary: True
+
+num_buckets_predict_pair: 64
+
+atom_encoder:
+  atom_dim: 64
+  atom_dim_pair: 16
+  n_queries: 32
+  n_keys: 128
+  n_layers: 3
+  nheads: 4
+  apply_rotary: False
+
+atom_decoder:
+  atom_dim: 64
+  atom_dim_pair: 16
+  n_queries: 32
+  n_keys: 128
+  n_layers: 3
+  nheads: 4
+  apply_rotary: False

--- a/configs/experiment_config/training_bb.yaml
+++ b/configs/experiment_config/training_bb.yaml
@@ -1,0 +1,69 @@
+run_name_: train_run_8gpu_bb_run1
+
+hardware:
+  ncpus_per_task_train_: 24  # Number of CPUs per tast during training
+  ncpus_per_task_prepro_: 32  # Number of CPUs used for data preprocessing run
+  accelerator: gpu
+  ngpus_per_node_: 8  # Number of GPUs per node
+  nnodes_: 1  # Number of nodes
+
+# Below, for t_distribution, options are
+# - name: uniform. p2 is the maximum time that we can sample (<=1, p1 is ignored).
+# - name: logit-normal (normal + sigmoid). p1 is the mean of the normal, p2 the std (>0).
+# - name: beta. This is beta(p1, p2).
+loss:
+  t_distribution:
+    name: mix_up02_beta
+    p1: 1.9
+    p2: 1.0
+  loss_t_clamp: 0.9  # Used for loss stability in frameflow, 1. for no clamping
+  use_aux_loss: True  # Whether to use auxiliary loss
+  aux_loss_t_lim: 0.3  # Time limit to apply auxiliary loss
+  thres_aux_2d_loss: 0.6  # This is nm not Å
+  aux_loss_weight: 1.0
+  num_dist_buckets: 64  # Number of buckets to discretize the pairwise distance
+  max_dist_boundary: 1.0  # Given by nanometer
+
+
+defaults:
+  - model: bbflow  # caflow or frameflow
+  - _self_
+
+# Dataset params
+dataset: d_FS
+dataset_config_subdir: afdb
+
+force_precision_f32: False  # If false will use bf16-mixed precision
+
+training:
+  self_cond: True
+  fold_cond: False
+  mask_T_prob: 0.5
+  mask_A_prob: 0.5
+  mask_C_prob: 0.5
+  fold_label_sample_ratio: [0.5, 0.1, 0.15, 0.25]   # Training proportion for [None, C, CA, CAT]. If specified, will override mask_{C,A,T}_prob
+
+opt:
+  lr: 0.0001
+  max_epochs: 10000000
+  log_every_n_steps: 1  # For wandb
+  accumulate_grad_batches: 1
+  val_check_interval: 10000  # Number of training steps after which we check validation loss
+  skip_nan_grad: False  # Skip updates with nan gradient
+  grad_and_weight_analysis: False  # Log some statistics of gradients and weights
+  dist_strategy: ddp  # For multi GPU training, do not change
+
+log:
+  wandb_project: protein_transformer_bb  # Leave this so we can compare runs easily
+  log_wandb: True  # whether to log to wandb
+  checkpoint: True  # whether to store checkpoints
+  checkpoint_every_n_steps: 10000  # How often we store a checkpoint, should be greater than val_check_interval above
+  last_ckpt_every_n_steps: 3000  # How often do we update our last ckpt, needed for requeuing without losing progress
+
+seed: 42
+
+ema:
+  decay: 0.999  # 0 means no EMA, so all the EMA machinery is unused and no EMA checkpoints are stored
+  validate_original_weights: False  # Whether to run validation on regular or EMA weights
+  every_n_steps: 1  # Frequency of EMA updates
+  cpu_offload: False  # Whether to offload EMA weights to cpu

--- a/proteinfoundation/inference_bb.py
+++ b/proteinfoundation/inference_bb.py
@@ -1,0 +1,423 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+import os
+import sys
+from typing import List
+
+root = os.path.abspath(".")
+sys.path.append(root)  # Adds project's root directory
+
+import argparse
+import random
+import shutil
+import loralib as lora
+
+import hydra
+import lightning as L
+import numpy as np
+import pandas as pd
+import torch
+from dotenv import load_dotenv
+from loguru import logger
+from omegaconf import OmegaConf
+from torch.utils.data import DataLoader, Dataset
+from proteinfoundation.utils.lora_utils import replace_lora_layers
+
+
+from proteinfoundation.metrics.designability import scRMSD
+from proteinfoundation.metrics.metric_factory import (
+    GenerationMetricFactory,
+    generation_metric_from_list,
+)
+from proteinfoundation.proteinflow.proteinb import Proteinb
+from proteinfoundation.utils.ff_utils.pdb_utils import mask_cath_code_by_level, write_prot_to_pdb
+
+
+# Length dataloader for validation and inference
+class GenDataset(Dataset):
+    """
+    Dataset that indicates length of the proteins to generate,
+    discretization step size, and number of samples per length,
+    empirical (len, cath_code) joint distribution.
+    """
+
+    bucket_min_len = 50
+    bucket_max_len = 274
+    bucket_step_size = 25
+
+    def __init__(self, nres=[110], dt=0.005, nsamples=10, len_cath_codes=None):
+        # nres is a list of integers
+        # len_cath_codes is a list of [len, List[cath_code]] pairs, representing (len, cath_code) joint distribution
+        super(GenDataset, self).__init__()
+        self.nres = [int(n) for n in nres]
+        self.dt = dt
+        if isinstance(nsamples, List):
+            assert len(nsamples) == len(nres)
+            self.nsamples = nsamples
+        elif isinstance(nsamples, int):
+            self.nsamples = [nsamples] * len(nres)
+        else:
+            raise ValueError(f"Unknown type of nsamples {type(nsamples)}")
+        self.cath_codes_given_len_bucket = self.bucketize(len_cath_codes)
+
+    def bucketize(self, len_cath_codes):
+        """Build length buckets for cath_codes. Record the cath_code distribution given length bucket"""
+        if len_cath_codes is None:
+            return None
+        bucket = list(
+            range(self.bucket_min_len, self.bucket_max_len, self.bucket_step_size)
+        )
+        cath_codes_given_len_bucket = [[] for _ in range(len(bucket))]
+        for _len, code in len_cath_codes:
+            bucket_idx = (_len - self.bucket_min_len) // self.bucket_step_size
+            cath_codes_given_len_bucket[bucket_idx].append(code)
+        return cath_codes_given_len_bucket
+
+    def __len__(self):
+        return len(self.nres)
+
+    def __getitem__(self, index):
+        result = {
+            "nres": self.nres[index],
+            "dt": self.dt,
+            "nsamples": self.nsamples[index],
+        }
+        if self.cath_codes_given_len_bucket is not None:
+            if self.nres[index] <= self.bucket_max_len:
+                bucket_idx = (
+                    self.nres[index] - self.bucket_min_len
+                ) // self.bucket_step_size
+            else:
+                bucket_idx = -1
+            result["cath_code"] = random.choices(
+                self.cath_codes_given_len_bucket[bucket_idx], k=self.nsamples[index]
+            )
+        return result
+
+
+def split_nlens(nlens_dict, max_nsamples=16, n_replica=1):
+    """
+    Split nlens into data points (len, nsample) as val dataset and guarantee that
+        1. len(val_dataset) should be a multiple of n_replica, to ensure that we don't introduce additional samples for multi-gpu validation
+        2. nsample should be the same for all data points if n_replica > 1 (multi-gpu)
+
+    Args:
+        nlens_dict: Dict of nlens distribution.
+            nlens_dict["length_ranges"] is a set of bin boundaries.
+            nlens_dict["length_distribution"] is the numbers of samples in each bin
+        max_nsamples: Maximum nsample in each data point
+        n_replica: Number of GPUs
+
+    Returns:
+        lens_sample (List[int]): List of len for val data points
+        nsamples (List[int]): List of nsample for val data points
+    """
+    lengths_range = nlens_dict["length_ranges"].tolist()
+    length_distribution = nlens_dict["length_distribution"].tolist()
+    lens_sample, nsamples = [], []
+    for length, cnt in zip(lengths_range, length_distribution):
+        for i in range(0, cnt, max_nsamples):
+            lens_sample.append(length)
+            if i + max_nsamples <= cnt:
+                nsamples.append(max_nsamples)
+            else:
+                nsamples.append(cnt - i)
+
+    max_nsamples = max(nsamples)
+    for i in range(len(nsamples)):
+        nsamples[i] += max_nsamples - nsamples[i]
+
+    while len(lens_sample) % n_replica != 0:
+        lens_sample.append(lens_sample[-1])
+        nsamples.append(max_nsamples)
+
+    return lens_sample, nsamples
+
+
+def parse_nlens_cfg(cfg):
+    """Parse lengths distribution. Either loading an empirical one or build with arguments in yaml file"""
+    if cfg.get("nres_lens_distribution_path") is not None:
+        # Sample according to length distribution
+        nlens_dict = torch.load(cfg.nres_lens_distribution_path)
+    else:
+        # Sample with pre-specified lengths
+        if cfg.nres_lens:
+            _lens_sample = cfg.nres_lens
+        else:
+            _lens_sample = [
+                int(v)
+                for v in np.arange(cfg.min_len, cfg.max_len + 1, cfg.step_len).tolist()
+            ]
+        nlens_dict = {
+            "length_ranges": torch.as_tensor(_lens_sample),
+            "length_distribution": torch.as_tensor(
+                [cfg.nsamples_per_len] * len(_lens_sample)
+            ),
+        }
+    return nlens_dict
+
+
+def parse_len_cath_code(cfg):
+    """Load (len, cath_codes) joint distribution. Apply mask according to the guidance cath code level"""
+    if cfg.get("len_cath_code_path") is not None:
+        logger.info(
+            f"Loading empirical (length, cath_code) distribution from {cfg.len_cath_code_path}"
+        )
+        _len_cath_codes = torch.load(cfg.len_cath_code_path)
+        level = cfg.get("cath_code_level")
+        len_cath_codes = []
+        for i in range(len(_len_cath_codes)):
+            _len, code = _len_cath_codes[i]
+            code = mask_cath_code_by_level(code, level="H")
+            if level == "A" or level == "C":
+                code = mask_cath_code_by_level(code, level="T")
+                if level == "C":
+                    code = mask_cath_code_by_level(code, level="A")
+            len_cath_codes.append((_len, code))
+    else:
+        logger.info(
+            "No empirical (length, cath_code) distribution provided. Use unconditional training."
+        )
+        len_cath_codes = None
+    return len_cath_codes
+
+
+if __name__ == "__main__":
+    load_dotenv()
+
+    parser = argparse.ArgumentParser(description="Job info")
+    parser.add_argument(
+        "--config_name",
+        type=str,
+        default="inference_base",
+        help="Name of the config yaml file.",
+    )
+    parser.add_argument(
+        "--config_number", type=int, default=-1, help="Number of the config yaml file."
+    )
+    parser.add_argument(
+        "--config_subdir",
+        type=str,
+        help="(Optional) Name of directory with config files, if not included uses base inference config.\
+            Likely only used when submitting to the cluster with script.",
+    )
+    parser.add_argument(
+        "--split_id",
+        type=int,
+        default=0,
+        help="Leave as 0.",
+    )
+    args = parser.parse_args()
+    logger.info(" ".join(sys.argv))
+
+    assert (
+        torch.cuda.is_available()
+    ), "CUDA not available"  # Needed for ESMfold and designability
+    logger.add(
+        sys.stdout,
+        format="{time:YYYY-MM-DD HH:mm:ss} | {level} | {file}:{line} | {message}",
+    )  # Send to stdout
+
+    # Inference config
+    # If config_subdir is None then use base inference config
+    # Otherwise use config_subdir/some_config
+    if args.config_subdir is None:
+        config_path = "../configs/experiment_config"
+    else:
+        config_path = f"../configs/experiment_config/{args.config_subdir}"
+
+    with hydra.initialize(config_path, version_base=hydra.__version__):
+        # If number provided use it, otherwise name
+        if args.config_number != -1:
+            config_name = f"inf_{args.config_number}"
+        else:
+            config_name = args.config_name
+        cfg = hydra.compose(config_name=config_name)
+        logger.info(f"Inference config {cfg}")
+        run_name = cfg.run_name_
+
+    assert (
+        not cfg.compute_designability or not cfg.compute_fid
+    ), "Designability cannot be computed together with FID"
+
+    # Set root path for this inference run
+    root_path = f"./inference/{config_name}"
+    if os.path.exists(root_path):
+        shutil.rmtree(root_path)
+    os.makedirs(root_path, exist_ok=True)
+
+    # Load model from checkpoint
+    ckpt_path = cfg.ckpt_path
+    ckpt_file = os.path.join(ckpt_path, cfg.ckpt_name)
+    logger.info(f"Using checkpoint {ckpt_file}")
+    assert os.path.exists(ckpt_file), f"Not a valid checkpoint {ckpt_file}"
+
+    # Check if using lora and load model
+    if not cfg.lora.use:
+        model = Proteinb.load_from_checkpoint(ckpt_file)
+    
+    else: # If using lora, create lora layers and reload the state_dict
+        model = Proteinb.load_from_checkpoint(ckpt_file, strict=False)
+        logger.info("Re-create LoRA layers and reload the weights now")
+        replace_lora_layers(
+            model,
+            cfg["lora"]["r"],
+            cfg["lora"]["lora_alpha"],
+            cfg["lora"]["lora_dropout"],
+        )
+        lora.mark_only_lora_as_trainable(model, bias=cfg["lora"]["train_bias"])
+        ckpt = torch.load(ckpt_file, map_location="cpu")
+        model.load_state_dict(ckpt["state_dict"])
+
+    # Set seed
+    logger.info(f"Seeding everything to seed {cfg.seed}")
+    L.seed_everything(cfg.seed)
+
+    # Set inference variables and potentially load autoguidance
+    nn_ag = None
+    if (
+        cfg.get("autoguidance_ratio", 0.0) > 0
+        and cfg.get("guidance_weight", 1.0) != 1.0
+    ):
+        assert cfg.autoguidance_ckpt_path is not None
+        ckpt_ag_file = cfg.autoguidance_ckpt_path
+        model_ag = Proteinb.load_from_checkpoint(ckpt_ag_file)
+        nn_ag = model_ag.nn
+
+    model.configure_inference(cfg, nn_ag=nn_ag)
+
+    # Create length dataset
+    nlens_dict = parse_nlens_cfg(cfg)
+    lens_sample, nsamples = split_nlens(
+        nlens_dict, max_nsamples=cfg.max_nsamples, n_replica=1
+    )  # Assume running on 1 GPU
+    if cfg.fold_cond:
+        len_cath_codes = parse_len_cath_code(cfg)
+    else:
+        len_cath_codes = None
+    dataset = GenDataset(
+        nres=lens_sample, nsamples=nsamples, dt=cfg.dt, len_cath_codes=len_cath_codes
+    )
+    dataloader = DataLoader(dataset, batch_size=1)
+    # Note: Batch size should be left as 1, it is not the actual batch size.
+    # Each sample returned by this loader is a 3-tuple (L, nsamples, dt) where
+    #   - L (int) is the number of residues in the proteins to be samples
+    #   - nsamples (int) is the number of proteins to generate (happens in parallel),
+    #     so if nsamples=10 it means that it will produce 10 proteins of length L (all sampled in parallel)
+    #   - dt (float) step-size used for the ODE integrator
+    #   - cath_code (Optional[List[str]]) cath code for conditional generation
+
+    # Flatten config and use it to initialize results dataframes columns
+    flat_cfg = OmegaConf.to_container(cfg, resolve=True, enum_to_str=True)
+    flat_dict = pd.json_normalize(flat_cfg, sep="_").to_dict(orient="records")[0]
+    flat_dict = {k: str(v) for k, v in flat_dict.items()}
+    columns = list(flat_dict.keys())
+
+    # Sample the model
+    trainer = L.Trainer(accelerator="gpu", devices=1, logger=False)
+    predictions = trainer.predict(model, dataloader)
+
+    # Code for designability and
+    # Store samples generated as pdbs and also scRMSD
+
+    # Add some columns to store per-sample results
+    columns += ["id_gen", "pdb_path", "L"]
+    if cfg.compute_designability:
+        columns += ["_res_scRMSD", "_res_scRMSD_all"]
+
+    results = []
+    samples_per_length = {}
+    for pred in predictions:
+        coors_atom37 = pred  # [b, n, 37, 3], prediction_step returns atom37
+        n = coors_atom37.shape[-3]
+        if n not in samples_per_length:
+            samples_per_length[n] = 0
+
+        # Save each generation as a pdb file
+        for i in range(coors_atom37.shape[0]):
+            # Create directory where everything related to this sample will be stored
+            dir_name = f"n_{n}_id_{samples_per_length[n]}"
+            samples_per_length[n] += 1
+            sample_root_path = os.path.join(
+                root_path, dir_name
+            )  # ./inference/conf_{}/n_{}_id_{}
+            os.makedirs(sample_root_path, exist_ok=False)
+
+            # Save generated structure as pdb
+            fname = dir_name + ".pdb"
+            pdb_path = os.path.join(sample_root_path, fname)
+            write_prot_to_pdb(
+                coors_atom37[i].numpy(),
+                pdb_path,
+                overwrite=True,
+                no_indexing=True,
+            )
+
+            res_row = list(flat_dict.values()) + [i, pdb_path, n]
+
+            # If needed run designability, storing all intermediate values generated in sample_root_path
+            if cfg.compute_designability:
+                res_designability = scRMSD(
+                    pdb_path, ret_min=False, tmp_path=sample_root_path, ca_only=cfg.ca_only
+                )
+                res_row += [min(res_designability), res_designability]
+                print(res_designability)
+
+            results.append(res_row)
+
+    # Create the dataframe with results
+    df = pd.DataFrame(results, columns=columns)
+
+    # Code for FID
+    if cfg.compute_fid:
+        # Create directory to store all samples
+        samples_dir_fid = os.path.join(root_path, "samples_fid")
+        os.makedirs(samples_dir_fid, exist_ok=True)
+
+        # Store samples
+        list_of_pdbs = []
+        for pred in predictions:
+            coors_atom37 = pred  # [b, n, 37, 3], prediction_step returns atom37
+            for i in range(coors_atom37.shape[0]):
+                pdb_path = os.path.join(samples_dir_fid, f"{len(list_of_pdbs)}_fid.pdb")
+                write_prot_to_pdb(
+                    coors_atom37[i].numpy(),
+                    pdb_path,
+                    overwrite=True,
+                    no_indexing=True,
+                )
+                list_of_pdbs.append(pdb_path)
+
+        # Initialize row with results
+        res_row = list(flat_dict.values())
+
+        # Compute metrics and add respective columns and values
+        for cfg_mf in cfg.metric_factory:
+            if isinstance(model, Proteinb):
+                assert cfg_mf.ca_only == True, "Please turn on ca_only for CAFlow model"
+            metric_factory = GenerationMetricFactory(**cfg_mf).cuda()
+            metrics = generation_metric_from_list(list_of_pdbs, metric_factory)
+            for k, v in metrics.items():
+                columns += ["_res_" + k]
+                res_row += [v.cpu().item()]
+
+        # Create dataframe
+        df = pd.DataFrame([res_row], columns=columns)
+        df = df.drop("metric_factory", axis=1)  # For nicer table
+
+    # Write results to csv file
+    if cfg.compute_fid:
+        df.to_csv(
+            os.path.join(root_path, "..", f"results_{config_name}_fid.csv"), index=False
+        )
+    else:
+        csv_file = os.path.join(root_path, "..", f"results_{config_name}.csv")
+        df.to_csv(csv_file, index=False)

--- a/proteinfoundation/metrics/designability.py
+++ b/proteinfoundation/metrics/designability.py
@@ -216,7 +216,7 @@ def run_and_store_esm(
     # Store generations for each sequence
     out_esm_paths = []
     for i, pdb in enumerate(list_of_strings_pdb):
-        fname = f"esm_{i+1}.pdb_esm"
+        fname = f"esm_{i+1}.pdb"
         fdir = os.path.join(path_to_esmfold_out, fname)
         with open(fdir, "w") as f:
             f.write(pdb)
@@ -266,7 +266,12 @@ def rmsd_metric(
         assert mask_1_atom_37.shape == coors_1_atom37.shape[1:]
     if mask_2_atom_37 is not None:
         assert mask_2_atom_37.shape == coors_2_atom37.shape[1:]
-    idx_select = [1]  # [CA]
+    if mode == "ca":
+        idx_select = [1]  # [CA]
+    elif mode == "backbone":
+        idx_select = [0, 1, 2]
+    else:
+        raise ValueError(f"Invalid mode: {mode}")
 
     coors_1 = coors_1_atom37[:, idx_select, :]  # [n, natoms_sel, 3]
     coors_2 = coors_2_atom37[:, idx_select, :]  # [n, natoms_sel, 3]
@@ -294,6 +299,7 @@ def scRMSD(
     num_seq_per_target: int = 8,
     pmpnn_sampling_temp: float = 0.1,
     ret_min=True,
+    ca_only=True,
 ) -> Union[float, List[float]]:
     """
     Evaluates self-consistency RMSD metrics for given pdb.
@@ -317,6 +323,7 @@ def scRMSD(
         tmp_path,
         num_seq_per_target=num_seq_per_target,
         sampling_temp=pmpnn_sampling_temp,
+        ca_only=ca_only,
     )  # List of sequences
 
     logger.info(f"Running ESMFold for {name}")

--- a/proteinfoundation/nn/alphafold3_pytorch_utils/utils.py
+++ b/proteinfoundation/nn/alphafold3_pytorch_utils/utils.py
@@ -1,0 +1,514 @@
+from typing import Union, Optional
+import torch
+import torch.nn.functional as F
+import math
+from torch_scatter import scatter
+
+
+
+def pad_at_dim(
+    x: torch.Tensor,
+    dim: int,
+    pad_length: Union[tuple[int], list[int]],
+    value: float = 0,
+) -> torch.Tensor:
+    """pad to input x at dimension dim with length pad_length[0] to the left and and pad_length[1] to the right.
+
+    Args:
+        x (torch.Tensor): input
+        dim (int): padding dimension
+        pad_length (Union[Tuple[int], List[int]]): length to pad to the beginning and end.
+
+    Returns:
+        torch.Tensor: padded tensor
+    """
+    n_dim = len(x.shape)
+    if dim < 0:
+        dim = n_dim + dim
+
+    pad = (pad_length[0], pad_length[1])
+    if pad == (0, 0):
+        return x
+    k = n_dim - (dim + 1)
+    if k > 0:
+        pad_skip = (0, 0) * k
+        pad = (*pad_skip, *pad)
+    return F.pad(x, pad=pad, value=value)
+
+
+def reshape_at_dim(
+    x: torch.Tensor, dim: int, target_shape: Union[tuple[int], list[int]]
+) -> torch.Tensor:
+    """reshape dimension dim of x to target_shape
+
+    Args:
+        x (torch.Tensor): input
+        dim (int): dimension to reshape
+        target_shape (Union[Tuple[int], List[int]]): target_shape of dim
+
+    Returns:
+        torch.Tensor: reshaped tensor
+    """
+    n_dim = len(x.shape)
+    if dim < 0:
+        dim = n_dim + dim
+
+    target_shape = tuple(target_shape)
+    target_shape = (*x.shape[:dim], *target_shape)
+    if dim + 1 < n_dim:
+        target_shape = (*target_shape, *x.shape[dim + 1 :])
+    return x.reshape(target_shape)
+
+
+def move_final_dim_to_dim(x: torch.Tensor, dim: int) -> torch.Tensor:
+    """
+    Move the final dimension of a tensor to a specified dimension.
+
+    Args:
+        x (torch.Tensor): Input tensor.
+        dim (int): Target dimension to move the final dimension to.
+
+    Returns:
+        torch.Tensor: Tensor with the final dimension moved to the specified dimension.
+    """
+    # permute_final_dims
+    n_dim = len(x.shape)
+    if dim < 0:
+        dim = n_dim + dim
+    if dim >= n_dim - 1:
+        return x
+
+    new_order = (n_dim - 1,)
+    if dim > 0:
+        new_order = tuple(range(dim)) + new_order
+    if dim < n_dim - 1:
+        new_order = new_order + tuple(range(dim, n_dim - 1))
+
+    return x.permute(new_order)
+
+
+def rearrange_qk_to_dense_trunk(
+    q: Union[torch.Tensor, list[torch.Tensor]],
+    k: Union[torch.Tensor, list[torch.Tensor]],
+    dim_q: Union[int, list[int]],
+    dim_k: Union[int, list[int]],
+    n_queries: int = 32,
+    n_keys: int = 128,
+    compute_mask: bool = True,
+) -> tuple[Union[torch.Tensor, list[torch.Tensor]]]:
+    """Rearrange q/k into blocked tensors for local operations.
+
+    Args:
+        q (torch.Tensor): query tensor. Could be a tensor or a list of tensors.
+            [..., n_q, ...] (n_q is at dimension dim_q)
+        k (torch.Tensor | List[torch.Tensor]): key tensor. Could be a tensor or a list of tensors.
+            [..., n_k, ...] (n_k is at dimension dim_k)
+        dim_q (int): along which dimension to build the trunks. Could be an int or a list of int.
+        dim_k (int): along which dimension to build the trunks. Could be an int or a list of int.
+        n_queries (int, optional): local window size of query tensor.
+        n_keys (int, optional): local window size of key/value tensor.
+
+    Returns:
+        tuple[Union[torch.Tensor, list[torch.Tensor]]]:
+            q_trunked: torch.Tensor or list of tensors. Same as the input type.
+                [..., n_trunks, n_queries, ...]
+            k_trunked: torch.Tensor or list of tensors. Same as the input type.
+                [..., n_trunks, n_keys, ...]
+            padding_info (dict):
+                mask_trunked: torch.Tensor
+                    [n_trunks, n_queries, n_keys]
+                q_pad: query padded dimension
+    """
+
+    assert n_keys >= n_queries
+    assert n_queries & 0x01 == 0
+    assert n_keys & 0x01 == 0
+
+    def basic_checks(x, dim_x):
+        if isinstance(x, list):
+            x_is_list = True
+            assert isinstance(dim_x, list)
+        else:
+            x_is_list = False
+            x = [x]
+            dim_x = [dim_x]
+        n_x = x[0].size(dim_x[0])
+        for i in range(len(dim_x)):
+            if dim_x[i] < 0:
+                dim_x[i] = len(x[i].shape) + dim_x[i]
+            assert x[i].size(dim_x[i]) == n_x
+        return x, dim_x, x_is_list, n_x, len(x)
+
+    q, dim_q, q_is_list, n, num_q = basic_checks(q, dim_q)
+    k, dim_k, k_is_list, n_k, num_k = basic_checks(k, dim_k)
+
+    assert n == n_k
+    n_trunks = int(math.ceil(n / n_queries))
+    q_pad_length = n_trunks * n_queries - n
+
+    q_new = [
+        pad_at_dim(q[i], dim=dim_q[i], pad_length=(0, q_pad_length))
+        for i in range(num_q)
+    ]
+    q_trunked = [
+        reshape_at_dim(q_new[i], dim=dim_q[i], target_shape=(n_trunks, n_queries))
+        for i in range(num_q)
+    ]
+
+    pad_left = (n_keys - n_queries) // 2
+    pad_right = int((n_trunks - 1 / 2) * n_queries + n_keys / 2 - n + 1 / 2)
+
+    k_new = [
+        pad_at_dim(k[i], dim=dim_k[i], pad_length=(pad_left, pad_right))
+        for i in range(num_k)
+    ]
+    k_trunked = [
+        k_new[i].unfold(dim_k[i], size=n_keys, step=n_queries) for i in range(num_k)
+    ]
+    k_trunked = [
+        move_final_dim_to_dim(k_trunked[i], dim=dim_k[i] + 1) for i in range(num_k)
+    ]
+
+    if compute_mask:
+        pad_mask = q[0].new_ones(
+            *(1,) * len(q[0].shape[:-2]),
+            n + q_pad_length,
+            n + pad_left + pad_right,
+            requires_grad=False,
+        )
+        pad_mask[..., :n, 0:pad_left] = 0
+        pad_mask[..., :n, pad_left + n : :] = 0
+        pad_mask[..., n::, :] = 0
+
+        concat_split_data = optimized_concat_split(pad_mask, n_queries)
+        pad_mask_trunked = (
+            concat_split_data.unfold(
+                -1, n_keys, pad_mask.size(-1) + n_queries
+            ).transpose(-2, -3)
+        ).bool()
+    else:
+        pad_mask_trunked = None
+
+    if not q_is_list:
+        q_trunked = q_trunked[0]
+    if not k_is_list:
+        k_trunked = k_trunked[0]
+
+    padding_info = {
+        "mask_trunked": pad_mask_trunked,
+        "q_pad": q_pad_length,
+        "k_pad_left": pad_left,
+        "k_pad_right": pad_right,
+    }
+
+    return q_trunked, k_trunked, padding_info
+
+
+def optimized_concat_split(attn_bias: torch.Tensor, n_queries: int) -> torch.Tensor:
+    """Optimized concatenation and splitting of attention bias tensor.
+
+    Args:
+        attn_bias (torch.Tensor): The attention bias tensor.
+            Shape: [..., D, E]
+        n_queries (int): The number of queries in each split.
+
+    Returns:
+        torch.Tensor: The reshaped and permuted attention bias tensor.
+            Shape: [..., n_queries, D // n_queries * E]
+    """
+    D = attn_bias.size(-2)
+    E = attn_bias.size(-1)
+    assert D % n_queries == 0
+    num_splits = D // n_queries
+    reshaped = attn_bias.reshape(*attn_bias.shape[:-2], num_splits, n_queries, E)
+    permuted = reshaped.permute(*range(reshaped.dim() - 3), -2, -3, -1)
+    output = permuted.reshape(*attn_bias.shape[:-2], n_queries, num_splits * E)
+    return output
+
+
+def rearrange_to_dense_trunk(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    n_queries: int,
+    n_keys: int,
+    attn_bias: Optional[torch.Tensor] = None,
+    inf: float = 1e10,
+) -> tuple[Union[torch.Tensor, int]]:
+    """Rearrange q/k/v/bias into blocked tensors for local attention.
+
+    Args:
+        q (torch.Tensor): query tensor
+            [..., n_q, d]
+        k (torch.Tensor): key tensor
+            [..., n_kv, d]
+        v (torch.Tensor): value tensor
+            [..., n_kv, d]
+        attn_bias (torch.Tensor, optional): attention bias
+            [..., n_q, n_kv] or None
+        n_queries (int, optional): local window size of query tensor.
+        n_keys (int, optional): local window size of key/value tensor.
+        inf (float, optional): used for attention masking. Defaults to 1e10.
+
+    Returns:
+        tuple[Union[torch.Tensor, int]]:
+            q_trunked
+                [..., n_trunks, n_queries, d]
+            k_trunked / v_trunked
+                [..., n_trunks, n_keys, d]
+            attn_bias_trunked:  padded position filled with -inf
+                [..., n_trunks, n_queries, n_keys]
+            q_pad_length: query padded dimension
+    """
+    assert n_keys >= n_queries
+    assert n_queries & 0x01 == 0
+    assert n_keys & 0x01 == 0
+
+    n, d = q.shape[-2:]
+
+    q_trunked, kv_trunked, padding_info = rearrange_qk_to_dense_trunk(
+        q=q,
+        k=[k, v],
+        dim_q=-2,
+        dim_k=[-2, -2],
+        n_queries=n_queries,
+        n_keys=n_keys,
+        compute_mask=False,
+    )
+    q_pad_length, pad_left, pad_right = (
+        padding_info["q_pad"],
+        padding_info["k_pad_left"],
+        padding_info["k_pad_right"],
+    )
+
+    # Padded_width = n + pad_left + pad_right
+    if attn_bias is None:
+        attn_bias = q.new_zeros(
+            *(1,) * len(q.shape[:-2]), n + q_pad_length, n + pad_left + pad_right
+        )
+        attn_bias[..., :n, 0:pad_left] = -inf
+        attn_bias[..., :n, pad_left + n : :] = -inf
+        attn_bias[..., n::, :] = -inf
+    else:
+        attn_bias = F.pad(attn_bias, (pad_left, pad_right, 0, q_pad_length), value=-inf)
+
+    concat_split_data = optimized_concat_split(attn_bias, n_queries)
+    attn_bias_trunked = concat_split_data.unfold(
+        -1, n_keys, attn_bias.shape[-1] + n_queries
+    ).transpose(-2, -3)
+    return q_trunked, kv_trunked[0], kv_trunked[1], attn_bias_trunked, q_pad_length
+
+
+def gather_pair_embedding_in_dense_trunk(
+    x: torch.Tensor, idx_q: torch.Tensor, idx_k: torch.Tensor
+):
+    """
+    Selectively gather elements from a tensor using two sets of indices.
+
+        x: [..., N_token, N_token, d]
+        idx_q: [N_b, N_q]
+        idx_k: [N_b, N_k]
+
+    Return:
+        y: [..., N_b, N_q, N_k, d]
+            where y[..., b, i, j, :] = x[..., idx_q[b, i], idx_k[b, j], :]
+    """
+    idx_q = idx_q.long()
+    idx_k = idx_k.long()
+
+    # Get the shape parameters
+    b, N_b, N_q = idx_q.shape
+    N_k = idx_k.shape[-1]
+    
+    bs_idx = torch.arange(b, device=x.device).view(b, 1, 1, 1).expand(b, N_b, N_q, N_k)
+
+    # Expand idx_q and idx_k to match the shape required for advanced indexing
+    idx_q_expanded = idx_q.unsqueeze(-1).expand(-1, -1, -1, N_k)
+    idx_k_expanded = idx_k.unsqueeze(-2).expand(-1, -1, N_q, -1)
+
+    # Use advanced indexing to gather the desired elements
+    y = x[bs_idx, idx_q_expanded, idx_k_expanded, :]
+
+    return y
+
+
+def broadcast_token_to_local_atom_pair(
+    z_token: torch.Tensor,
+    atom_to_token_idx: torch.Tensor,
+    n_queries: int,
+    n_keys: int,
+    compute_mask: bool = True,
+) -> torch.Tensor:
+    """Broadcast token pair embedding to atom pair embedding
+
+    Args:
+        z_token (torch.Tensor): token pair embedding
+            [..., N_token, N_token, d]
+        atom_to_token_idx (torch.Tensor): map atom idx to token idx
+            [N_atom]
+
+    Returns:
+        z_gathered_blocked (torch.Tensor): atom pair embedding, with local blocked shape
+            [..., n_trunks, n_queries, n_keys, d]
+        pad_mask (torch.Tensor):
+            [n_trunks, n_queries, n_keys]
+        q_pad_length (int)
+    """
+
+    # [N_atom] -> [n_trunks, n_queries] and [n_trunks, n_keys]
+    atom_to_token_idx_q, atom_to_token_idx_k, pad_info = rearrange_qk_to_dense_trunk(
+        atom_to_token_idx,
+        atom_to_token_idx,
+        dim_q=-1,
+        dim_k=-1,
+        n_queries=n_queries,
+        n_keys=n_keys,
+        compute_mask=compute_mask,
+    )
+
+    z_gathered_blocked = gather_pair_embedding_in_dense_trunk(
+        z_token, idx_q=atom_to_token_idx_q, idx_k=atom_to_token_idx_k
+    )
+
+    return z_gathered_blocked, pad_info
+
+
+# this is mostly from openfold.utils.torch_utils import batched_gather
+def batched_gather(
+    data: torch.Tensor, inds: torch.Tensor, dim: int = 0, no_batch_dims: int = 0
+) -> torch.Tensor:
+    """Gather data according to indices specify by inds
+
+    Args:
+        data (torch.Tensor): the input data
+            [..., K, ...]
+        inds (torch.Tensor): the indices for gathering data
+            [..., N]
+        dim (int, optional): along which dimension to gather data by inds (the dim of "K" "N"). Defaults to 0.
+        no_batch_dims (int, optional): length of dimensions before the "dim" dimension. Defaults to 0.
+
+    Returns:
+        torch.Tensor: gathered data
+            [..., N, ...]
+    """
+
+    # for the naive case
+    if len(inds.shape) == 1 and no_batch_dims == 0 and dim == 0:
+        return data[inds]
+
+    ranges = []
+    for i, s in enumerate(data.shape[:no_batch_dims]):
+        r = torch.arange(s)
+        r = r.view(*(*((1,) * i), -1, *((1,) * (len(inds.shape) - i - 1))))
+        ranges.append(r)
+
+    remaining_dims = [slice(None) for _ in range(len(data.shape) - no_batch_dims)]
+    remaining_dims[dim - no_batch_dims if dim >= 0 else dim] = inds
+    ranges.extend(remaining_dims)
+    return data[ranges]
+
+
+def broadcast_token_to_atom(
+    x_token: torch.Tensor, atom_to_token_idx: torch.Tensor
+) -> torch.Tensor:
+    """Broadcast token-level embeddings to atom-level embeddings
+
+    Args:
+        x_token (torch.Tensor): token embedding
+            [..., N_token, d]
+        atom_to_token_idx (torch.Tensor): map atom idx to token idx
+            [..., N_atom] or [N_atom]
+
+    Returns:
+        torch.Tensor: atom embedding
+            [..., N_atom, d]
+    """
+
+    if len(atom_to_token_idx.shape) == 1:
+        # shape = [N_atom], easy index
+        return x_token[..., atom_to_token_idx, :]
+    else:
+        assert atom_to_token_idx.shape[:-1] == x_token.shape[:-2]
+
+    return batched_gather(
+        data=x_token,
+        inds=atom_to_token_idx,
+        dim=-2,
+        no_batch_dims=len(x_token.shape[:-2]),
+    )
+    
+
+def aggregate_atom_to_token(
+    x_atom: torch.Tensor,
+    atom_to_token_idx: torch.Tensor,
+    n_token: int,
+    reduce: str = "mean",
+) -> torch.Tensor:
+    """Aggregate atom embedding to obtain token embedding
+
+    Args:
+        x_atom (torch.Tensor): atom-level embedding
+            [..., N_atom, d]
+        atom_to_token_idx (torch.Tensor): map atom to token idx
+            [..., N_atom] or [N_atom]
+        n_token (int, optional): number of tokens in total. Defaults to None.
+        reduce (str, optional): aggregation method. Defaults to "mean".
+
+    Returns:
+        torch.Tensor: token-level embedding
+            [..., N_token, d]
+    """
+
+    # Broadcasting in the given dim.
+    out = scatter(
+        src=x_atom, index=atom_to_token_idx, dim=-2, dim_size=n_token, reduce=reduce
+    )
+
+    return out
+
+
+# def create_local_attn_bias(
+#     n: int, n_queries: int, n_keys: int, inf: float = 1e10, device: torch.device = None
+# ) -> torch.Tensor:
+#     """Create local attention bias based on query window n_queries and kv window n_keys.
+
+#     Args:
+#         n (int): the length of quiries
+#         n_queries (int): window size of quiries
+#         n_keys (int): window size of keys/values
+#         inf (float, optional): the inf to mask attention. Defaults to 1e10.
+#         device (torch.device, optional): cuda|cpu|None. Defaults to None.
+
+#     Returns:
+#         torch.Tensor: the diagonal-like global attention bias
+#     """
+#     n_trunks = int(math.ceil(n / n_queries))
+#     padded_n = n_trunks * n_queries
+#     attn_mask = torch.zeros(padded_n, padded_n, device=device)
+#     for block_index in range(0, n_trunks):
+#         i = block_index * n_queries
+#         j1 = max(0, n_queries * block_index - (n_keys - n_queries) // 2)
+#         j2 = n_queries * block_index + (n_queries + n_keys) // 2
+#         attn_mask[i : i + n_queries, j1:j2] = 1.0
+#     attn_bias = (1 - attn_mask) * -inf
+#     return attn_bias.to(device=device)[:n, :n]
+    
+
+# def broadcast_token_to_atom_pair(
+#     x_pair: torch.Tensor, atom_to_token_idx: torch.Tensor
+# ) -> torch.Tensor:
+#     """Broadcast token-level embeddings to atom-level embeddings
+#     """
+    
+#     n_atoms = atom_to_token_idx.shape[-1]
+#     if len(atom_to_token_idx.shape) == 1:
+#         atom_to_token_idx = atom_to_token_idx[None]
+    
+#     indices_dim1 = atom_to_token_idx
+#     x_expanded_dim1 = batched_gather(x_pair, indices_dim1, dim=-3, no_batch_dims=1)
+
+#     indices_dim2 = einops.repeat(atom_to_token_idx, "b n -> b m n", m=n_atoms)
+#     # indices_dim2 = atom_to_token_idx.view(1, 1, n_atoms).expand(1, n_atoms, n_atoms)
+#     x_expanded = batched_gather(x_expanded_dim1, indices_dim2, dim=-2, no_batch_dims=2)
+    
+#     return x_expanded

--- a/proteinfoundation/nn/pair_bias_attn/pair_bias_attn.py
+++ b/proteinfoundation/nn/pair_bias_attn/pair_bias_attn.py
@@ -15,7 +15,10 @@ import torch
 from einops import rearrange
 from torch import Tensor, einsum, nn
 
-
+from proteinfoundation.nn.alphafold3_pytorch_utils.utils import (
+    rearrange_to_dense_trunk,
+)
+from proteinfoundation.nn.pair_bias_attn.rotary import RotaryEmbedding
 def exists(val) -> bool:
     """returns whether val is not none"""
     return val is not None
@@ -45,13 +48,17 @@ class PairBiasAttention(nn.Module):
         dim_out: int,
         qkln: bool,
         pair_dim: Optional[int] = None,
+        apply_rotary: bool = False,
         **kawrgs  # noqa
     ):
         super().__init__()
         inner_dim = dim_head * heads
         self.node_dim, self.pair_dim = node_dim, pair_dim
+        self.dim_head = dim_head
         self.heads, self.scale = heads, dim_head**-0.5
-        self.to_qkv = nn.Linear(node_dim, inner_dim * 3, bias=bias)
+        # self.to_qkv = nn.Linear(node_dim, inner_dim * 3, bias=bias)
+        self.to_q = nn.Linear(node_dim, inner_dim, bias=bias)
+        self.to_kv = nn.Linear(node_dim, inner_dim * 2, bias=bias)
         self.to_g = nn.Linear(node_dim, inner_dim)
         self.to_out_node = nn.Linear(inner_dim, default(dim_out, node_dim))
         self.node_norm = nn.LayerNorm(node_dim)
@@ -62,12 +69,23 @@ class PairBiasAttention(nn.Module):
             self.pair_norm = nn.LayerNorm(pair_dim)
         else:
             self.to_bias, self.pair_norm = None, None
+        self.rotary = RotaryEmbedding(dim=dim_head) if apply_rotary else None
+            
+    def _apply_rotary(self, q: torch.Tensor, k: torch.Tensor):
+        q = q.unflatten(-1, (self.heads, self.dim_head))
+        k = k.unflatten(-1, (self.heads, self.dim_head))
+        q, k = self.rotary(q, k)
+        q = q.flatten(-2, -1)
+        k = k.flatten(-2, -1)
+        return q, k
 
     def forward(
         self,
         node_feats: Tensor,
         pair_feats: Optional[Tensor],
         mask: Optional[Tensor],
+        n_queries: int,
+        n_keys: int,
     ) -> Tensor:
         """Multi-head scalar Attention Layer
 
@@ -79,9 +97,13 @@ class PairBiasAttention(nn.Module):
         assert exists(self.to_bias) or not exists(pair_feats)
         node_feats, h = self.node_norm(node_feats), self.heads
         pair_feats = self.pair_norm(pair_feats) if exists(pair_feats) else None
-        q, k, v = self.to_qkv(node_feats).chunk(3, dim=-1)
+        q = self.to_q(node_feats)
+        k, v = self.to_kv(node_feats).chunk(2, dim=-1)
         q = self.q_layer_norm(q)
         k = self.k_layer_norm(k)
+        # add rotary embedding
+        if self.rotary is not None:
+            q, k = self._apply_rotary(q, k)
         g = self.to_g(node_feats)
         b = (
             rearrange(self.to_bias(pair_feats), "b ... h -> b h ...")
@@ -91,7 +113,10 @@ class PairBiasAttention(nn.Module):
         q, k, v, g = map(
             lambda t: rearrange(t, "b ... (h d) -> b h ... d", h=h), (q, k, v, g)
         )
-        attn_feats = self._attn(q, k, v, b, mask)
+        if n_queries and n_keys:
+            attn_feats = self._local_attn(q, k, v, b, mask, n_queries, n_keys)
+        else:
+            attn_feats = self._attn(q, k, v, b, mask)
         attn_feats = rearrange(
             torch.sigmoid(g) * attn_feats, "b h n d -> b n (h d)", h=h
         )
@@ -105,3 +130,40 @@ class PairBiasAttention(nn.Module):
             sim = sim.masked_fill(~mask, max_neg_value(sim))
         attn = torch.softmax(sim + b, dim=-1)
         return einsum("b h i j, b h j d -> b h i d", attn, v)
+    
+    def _local_attn(
+        self,
+        q,
+        k,
+        v,
+        b,
+        mask: Optional[Tensor],
+        n_queries: int,
+        n_keys: int,
+        inf: float = 1e10
+    ) -> Tensor:
+        # Rerrange to dense trunks
+        # q: [*, n, d] -> [*, n_trunks, n_queries, d]
+        # attn_bias: [*, n, d] -> [*, n_trunks, n_queries, n_keys]
+        q_trunked, k_trunked, v_trunked, _, q_pad_length = (
+            rearrange_to_dense_trunk(
+                q=q,
+                k=k,
+                v=v,
+                n_queries=n_queries,
+                n_keys=n_keys,
+                attn_bias=None,
+                inf=inf,
+            )
+        )
+        
+        sim = einsum("b h n i d, b h n j d -> b h n i j", q_trunked, k_trunked) * self.scale
+        if exists(mask):
+            mask = rearrange(mask, "b n i j -> b () n i j")
+            sim = sim.masked_fill(~mask, max_neg_value(sim))
+        attn = torch.softmax(sim + b, dim=-1)
+        out = einsum("b h n i j, b h n j d -> b h n i d", attn, v_trunked)
+        out = out.reshape(*out.shape[:-3], -1, out.shape[-1])
+        if q_pad_length > 0:
+            out = out[..., :-q_pad_length, :]
+        return out

--- a/proteinfoundation/nn/pair_bias_attn/rotary.py
+++ b/proteinfoundation/nn/pair_bias_attn/rotary.py
@@ -1,0 +1,199 @@
+from typing import Tuple
+
+import torch
+from einops import rearrange, repeat
+
+
+def rotate_half(x, interleaved=False):
+    if not interleaved:
+        x1, x2 = x.chunk(2, dim=-1)
+        return torch.cat((-x2, x1), dim=-1)
+    else:
+        x1, x2 = x[..., ::2], x[..., 1::2]
+        return rearrange(
+            torch.stack((-x2, x1), dim=-1), "... d two -> ... (d two)", two=2
+        )
+
+
+def apply_rotary_emb_torch(x, cos, sin, interleaved=False, _inplace=False):
+    """
+    x: (batch_size, seqlen, nheads, headdim)
+    cos, sin: (seqlen, rotary_dim / 2)
+    """
+    ro_dim = cos.shape[-1] * 2
+    assert ro_dim <= x.shape[-1]
+    seqlen = x.size(1)
+    cos = cos[:seqlen]
+    sin = sin[:seqlen]
+    cos = repeat(cos, "s d -> s 1 (2 d)")
+    sin = repeat(sin, "s d -> s 1 (2 d)")
+    return torch.cat(
+        [
+            x[..., :ro_dim] * cos + rotate_half(x[..., :ro_dim], interleaved) * sin,
+            x[..., ro_dim:],
+        ],
+        dim=-1,
+    )
+
+
+class RotaryEmbedding(torch.nn.Module):
+    """
+    The rotary position embeddings from RoFormer_ (Su et. al).
+    A crucial insight from the method is that the query and keys are
+    transformed by rotation matrices which depend on the relative positions.
+    Other implementations are available in the Rotary Transformer repo_ and in
+    GPT-NeoX_, GPT-NeoX was an inspiration
+    .. _RoFormer: https://arxiv.org/abs/2104.09864
+    .. _repo: https://github.com/ZhuiyiTechnology/roformer
+    .. _GPT-NeoX: https://github.com/EleutherAI/gpt-neox
+    If scale_base is not None, this implements XPos (Sun et al., https://arxiv.org/abs/2212.10554).
+    A recommended value for scale_base is 512: https://github.com/HazyResearch/flash-attention/issues/96
+    Reference: https://github.com/sunyt32/torchscale/blob/main/torchscale/component/xpos_relative_position.py
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        base=10000.0,
+        interleaved=False,
+        scale_base=None,
+        scaling_factor=1.0,
+        pos_idx_in_fp32=True,
+        device=None,
+    ):
+        """
+        interleaved: if True, rotate pairs of even and odd dimensions (GPT-J style) instead
+            of 1st half and 2nd half (GPT-NeoX style).
+        pos_idx_in_fp32: if True, the position indices [0.0, ..., seqlen - 1] are in fp32,
+            otherwise they might be in lower precision.
+            This option was added because previously (before 2023-07-02), when we construct
+            the position indices, we use the dtype of self.inv_freq. In most cases this would
+            be fp32, but if the model is trained in pure bf16 (not mixed precision), then
+            self.inv_freq would be bf16, and the position indices are also in bf16.
+            Because of the limited precision of bf16 (e.g. 1995.0 is rounded to 2000.0), the
+            embeddings for some positions will coincide.
+            To maintain compatibility with models previously trained in pure bf16,
+            we add this option.
+        scaling_factor: RotaryEmbedding extended with linear scaling.
+        """
+        super().__init__()
+        self.dim = dim
+        self.base = float(base)
+        self.pos_idx_in_fp32 = pos_idx_in_fp32
+        # Generate and save the inverse frequency buffer (non trainable)
+        self.interleaved = interleaved
+        self.scale_base = scale_base
+        self.scaling_factor = scaling_factor
+        self.device = device
+
+        self._seq_len_cached = 0
+        self._cos_cached = None
+        self._sin_cached = None
+        self._cos_k_cached = None
+        self._sin_k_cached = None
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        inv_freq = self._compute_inv_freq(self.device)
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        arange = torch.arange(0, self.dim, 2, device=self.device, dtype=torch.float32)
+        scale = (
+            (arange + 0.4 * self.dim) / (1.4 * self.dim)
+            if self.scale_base is not None
+            else None
+        )
+        self.register_buffer("scale", scale)
+
+    def _compute_inv_freq(self, device=None):
+        return 1 / (
+            self.base
+            ** (
+                torch.arange(0, self.dim, 2, device=device, dtype=torch.float32)
+                / self.dim
+            )
+        )
+
+    def _update_cos_sin_cache(self, seqlen, device=None, dtype=None):
+        # Reset the tables if the sequence length has changed,
+        # if we're on a new device (possibly due to tracing for instance),
+        # or if we're switching from inference mode to training
+        if (
+            seqlen > self._seq_len_cached
+            or self._cos_cached is None
+            or self._cos_cached.device != device
+            or self._cos_cached.dtype != dtype
+            or (self.training and self._cos_cached.is_inference())
+        ):
+            self._seq_len_cached = seqlen
+            # We want fp32 here, not self.inv_freq.dtype, since the model could be loaded in bf16
+            # And the output of arange can be quite large, so bf16 would lose a lot of precision.
+            # However, for compatibility reason, we add an option to use the dtype of self.inv_freq.
+            if self.pos_idx_in_fp32:
+                t = torch.arange(seqlen, device=device, dtype=torch.float32)
+                t /= self.scaling_factor
+                # We want fp32 here as well since inv_freq will be multiplied with t, and the output
+                # will be large. Having it in bf16 will lose a lot of precision and cause the
+                # cos & sin output to change significantly.
+                # We want to recompute self.inv_freq if it was not loaded in fp32
+                if self.inv_freq.dtype != torch.float32:
+                    inv_freq = self.inv_freq.to(torch.float32)
+                else:
+                    inv_freq = self.inv_freq
+            else:
+                t = torch.arange(seqlen, device=device, dtype=self.inv_freq.dtype)
+                t /= self.scaling_factor
+                inv_freq = self.inv_freq
+            # Don't do einsum, it converts fp32 to fp16 under AMP
+            # freqs = torch.einsum("i,j->ij", t, self.inv_freq)
+            freqs = torch.outer(t, inv_freq)
+
+            if self.scale is None:
+                self._cos_cached = torch.cos(freqs).to(dtype)
+                self._sin_cached = torch.sin(freqs).to(dtype)
+            else:
+                power = (
+                    torch.arange(
+                        seqlen, dtype=self.scale.dtype, device=self.scale.device
+                    )
+                    - seqlen // 2
+                ) / self.scale_base
+                scale = self.scale.to(device=power.device) ** power.unsqueeze(-1)
+                # We want the multiplication by scale to happen in fp32
+                self._cos_cached = (torch.cos(freqs) * scale).to(dtype)
+                self._sin_cached = (torch.sin(freqs) * scale).to(dtype)
+                self._cos_k_cached = (torch.cos(freqs) / scale).to(dtype)
+                self._sin_k_cached = (torch.sin(freqs) / scale).to(dtype)
+
+    def forward(
+        self, q: torch.Tensor, k: torch.Tensor, seqlen_offset: int = 0
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        q: (batch, seqlen, nheads, headdim)
+        k: (batch, seqlen, nheads, headdim)
+        seqlen_offset: can be used in generation where the qkv being passed in is only the last
+        token in the batch.
+        """
+        self._update_cos_sin_cache(
+            q.shape[1] + seqlen_offset, device=q.device, dtype=q.dtype
+        )
+        assert self._cos_cached is not None
+        assert self._sin_cached is not None
+        if self.scale is None:
+            return (
+                apply_rotary_emb_torch(
+                    q,
+                    self._cos_cached[seqlen_offset:],
+                    self._sin_cached[seqlen_offset:],
+                    self.interleaved,
+                    True,  # inplace=True
+                ),
+                apply_rotary_emb_torch(
+                    k,
+                    self._cos_cached[seqlen_offset:],
+                    self._sin_cached[seqlen_offset:],
+                    self.interleaved,
+                    True,  # inplace=True
+                ),
+            )  # type: ignore
+        else:
+            assert False

--- a/proteinfoundation/proteinflow/proteinb.py
+++ b/proteinfoundation/proteinflow/proteinb.py
@@ -1,0 +1,592 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+
+import os
+from math import prod
+from typing import Dict
+import random
+
+import torch
+from einops import rearrange, repeat
+from jaxtyping import Bool, Float
+from lightning.pytorch.utilities.rank_zero import rank_zero_only
+from scipy.spatial.transform import Rotation
+from torch import Tensor
+
+from proteinfoundation.flow_matching.r3n_fm import R3NFlowMatcher
+from proteinfoundation.nn.protein_transformer import ProteinTransformerAF3
+from proteinfoundation.proteinflow.model_trainer_base import ModelTrainerBase, _extract_cath_code
+from proteinfoundation.utils.align_utils.align_utils import kabsch_align
+from proteinfoundation.utils.coors_utils import ang_to_nm, trans_nm_to_atom37
+from proteinfoundation.nn.motif_factory import SingleMotifFactory
+from proteinfoundation.utils.ff_utils.pdb_utils import mask_cath_code_by_level
+
+
+@rank_zero_only
+def create_dir(dir):
+    if not os.path.exists(dir):
+        os.makedirs(dir, exist_ok=True)
+
+
+def sample_uniform_rotation(
+    shape=tuple(), dtype=None, device=None
+) -> Float[Tensor, "*batch 3 3"]:
+    """
+    Samples rotations distributed uniformly.
+
+    Args:
+        shape: tuple (if empty then samples single rotation)
+        dtype: used for samples
+        device: torch.device
+
+    Returns:
+        Uniformly samples rotation matrices [*shape, 3, 3]
+    """
+    return torch.tensor(
+        Rotation.random(prod(shape)).as_matrix(),
+        device=device,
+        dtype=dtype,
+    ).reshape(*shape, 3, 3)
+
+
+class Proteinb(ModelTrainerBase):
+    def __init__(self, cfg_exp, store_dir=None):
+        super(Proteinb, self).__init__(cfg_exp=cfg_exp, store_dir=store_dir)
+        self.save_hyperparameters()
+
+        # Define flow matcher
+        self.ca_only = False
+        self.motif_conditioning = cfg_exp.training.get("motif_conditioning", False)
+        self.fm = R3NFlowMatcher(zero_com= not self.motif_conditioning, scale_ref=1.0)  # Work in nm
+        if self.motif_conditioning:
+            self.motif_conditioning_sequence_rep = cfg_exp.training.get("motif_conditioning_sequence_rep", False)
+            if self.motif_conditioning_sequence_rep:
+                if "motif_sequence_mask" not in cfg_exp.model.nn.feats_init_seq:
+                    cfg_exp.model.nn.feats_init_seq.append("motif_sequence_mask")
+                if "motif_x1" not in cfg_exp.model.nn.feats_init_seq:
+                    cfg_exp.model.nn.feats_init_seq.append("motif_x1")
+                
+            if "motif_structure_mask" not in cfg_exp.model.nn.feats_pair_repr:
+                cfg_exp.model.nn.feats_pair_repr.append("motif_structure_mask")
+            if "motif_x1_pair_dists" not in cfg_exp.model.nn.feats_pair_repr:
+                cfg_exp.model.nn.feats_pair_repr.append("motif_x1_pair_dists")
+            self.motif_factory = SingleMotifFactory(motif_prob=cfg_exp.training.get("motif_prob", 1.0))
+
+        # Neural network
+        self.nn = ProteinTransformerAF3(**cfg_exp.model.nn, ca_only=self.ca_only)
+
+        self.nparams = sum(p.numel() for p in self.nn.parameters() if p.requires_grad)
+
+        create_dir(self.val_path_tmp)
+
+    def align_wrapper(self, x_0, x_1, mask):
+        """Performs Kabsch on the translation component of x_0 and x_1."""
+        return kabsch_align(mobile=x_0, target=x_1, mask=mask)
+
+    def extract_clean_sample(self, batch):
+        """
+        Extracts clean sample, mask, batch size, protein length n, and dtype from the batch.
+        Applies augmentations if those are required.
+
+        Args:
+            batch: batch from dataloader.
+
+        Returns:
+            Tuple (x_1, mask, batch_shape, n, dtype)
+        """
+        # index of [N, CA, C, O] is [0, 1, 2, 4]
+        BB_INDEX = [0, 1, 2, 4]
+        x_1 = batch["coords"][:,:,BB_INDEX,:]  # [b, n, 4, 3]
+        x_1 = rearrange(x_1, "b n c d -> b (n c) d")  # [b, 4*n, 3]
+        coords_mask = batch["mask_dict"]["coords"][..., BB_INDEX, 0]  # [b, n, 4] boolean
+        mask = coords_mask[..., 1]
+        coords_mask = rearrange(coords_mask, "b n c -> b (n c)")  # [b, 4*n]
+        if self.cfg_exp.model.augmentation.global_rotation:
+            # CAREFUL: If naug_rot is > 1 this increases "batch size"
+            x_1, coords_mask = self.apply_random_rotation(
+                x_1, coords_mask, naug=self.cfg_exp.model.augmentation.naug_rot
+            )
+            mask = rearrange(
+                coords_mask,
+                "b (n c) -> b n c",
+                c=4
+            )[..., 1]
+        batch_shape = x_1.shape[:-2]
+        n = x_1.shape[-2]
+        return (
+            ang_to_nm(x_1),
+            mask,
+            coords_mask,
+            batch_shape,
+            n,
+            x_1.dtype,
+        )  # Since we work in nm throughout
+
+    def apply_random_rotation(self, x, mask, naug=1):
+        """
+        Applies random rotation augmentation. Each sample in the batch may receive more than one augmentation,
+        specified by the parameters naug. If naug > 1 this is basically increaseing the batch size from b to
+        naug * b. This should likely be implemented in the dataloaders.
+
+        Args:
+            - x: Data batch, shape [b, n, 3]
+            - mask: Binary, shape [b, n]
+            - naug: Number of augmentations to apply to each sample, effectively increasing batch size if >1.
+
+        Returns:
+            Augmented samples and mask, shapes [b * naug, n, 3] and [B * naug, n].
+        """
+        assert (
+            x.ndim == 3
+        ), f"Augmetations can only be used for simple (x_1) batches [b, n, 3], current shape is {x.shape}"
+        assert (
+            mask.ndim == 2
+        ), f"Augmetations can only be used for simple (mask) batches [b, n], current shape is {mask.shape}"
+        assert naug >= 1, f"Number of augmentations (int) should >= 1, currently {naug}"
+
+        # Repeat for multiple augmentations per sample
+        x = x.repeat([naug, 1, 1])  # [naug * b, n, 3]
+        mask = mask.repeat([naug, 1])  # [naug * b, n]
+
+        # Sample and apply rotations
+        rots = sample_uniform_rotation(
+            shape=x.shape[:-2], dtype=x.dtype, device=x.device
+        )  # [naug * b, 3, 3]
+        x_rot = torch.matmul(x, rots)
+        return self.fm._mask_and_zero_com(x_rot, mask), mask
+    
+    def training_step(self, batch, batch_idx):
+        """
+        Computes training loss for batch of samples.
+
+        Args:
+            batch: Data batch.
+
+        Returns:
+            Training loss averaged over batches.
+        """
+        val_step = batch_idx == -1  # validation step is indicated with batch_idx -1
+        log_prefix = "validation_loss" if val_step else "train"
+        
+        # Extract inputs from batch (our dataloader)
+        # This may apply augmentations, if requested in the config file
+        x_1, mask, coords_mask, batch_shape, n, dtype = self.extract_clean_sample(batch)
+
+        # Center and mask input
+        x_1 = self.fm._mask_and_zero_com(x_1, coords_mask)
+
+        # Sample time, reference and align reference to target
+        t = self.sample_t(batch_shape)
+        x_0 = self.fm.sample_reference(
+            n=n, shape=batch_shape, device=self.device, dtype=dtype, mask=coords_mask
+        )
+        
+        if self.motif_conditioning:
+            batch.update(self.motif_factory(batch))
+            x_1 = batch["x_1"] # we need this since we change x_1 based n the motif center
+        # Interpolation
+        x_t = self.fm.interpolate(x_0, x_1, t)
+        # Add a few things to batch, needed for nn
+        batch["t"] = t
+        batch["mask"] = mask
+        batch["coords_mask"] = coords_mask
+        batch["x_t"] = x_t
+
+        # Fold conditional training
+        if self.cfg_exp.training.fold_cond:
+            bs = x_1.shape[0]
+            cath_code_list = batch.cath_code
+            for i in range(bs):
+                # Progressively mask T, A, C levels
+                cath_code_list[i] = mask_cath_code_by_level(
+                    cath_code_list[i], level="H"
+                )
+                if random.random() < self.cfg_exp.training.mask_T_prob:
+                    cath_code_list[i] = mask_cath_code_by_level(
+                        cath_code_list[i], level="T"
+                    )
+                    if random.random() < self.cfg_exp.training.mask_A_prob:
+                        cath_code_list[i] = mask_cath_code_by_level(
+                            cath_code_list[i], level="A"
+                        )
+                        if random.random() < self.cfg_exp.training.mask_C_prob:
+                            cath_code_list[i] = mask_cath_code_by_level(
+                                cath_code_list[i], level="C"
+                            )
+            batch.cath_code = cath_code_list
+        else:
+            if "cath_code" in batch:
+                batch.pop("cath_code")
+
+        # Prediction for self-conditioning
+        if random.random() > 0.5 and self.cfg_exp.training.self_cond:
+            x_pred_sc, _ = self.predict_clean(batch)
+            x_pred_sc = rearrange(
+                x_pred_sc,
+                "b (n c) d -> b n c d",
+                c=4
+            )[..., 1, :]
+            batch["x_sc"] = self.detach_gradients(x_pred_sc)
+
+        x_1_pred, nn_out = self.predict_clean(batch)
+
+        # Compute losses
+        fm_loss = self.compute_fm_loss(
+            x_1, x_1_pred, x_t, t, mask, coords_mask, log_prefix=log_prefix
+        )  # [*]
+        train_loss = torch.mean(fm_loss)
+        
+        if self.cfg_exp.loss.use_aux_loss:
+            auxiliary_loss = self.compute_auxiliary_loss(
+                x_1, x_1_pred, x_t, t, mask, nn_out=nn_out, log_prefix=log_prefix, batch=batch
+            )  # [*] already includes loss weights
+            train_loss = train_loss + torch.mean(auxiliary_loss)
+
+        self.log(
+            f"{log_prefix}/loss",
+            train_loss,
+            on_step=True,
+            on_epoch=True,
+            prog_bar=False,
+            logger=True,
+            batch_size=mask.shape[0],
+            sync_dist=True,
+            add_dataloader_idx=False,
+        )
+
+        # Don't log if validation step (indicated by batch_id)
+        if not val_step:
+            self.log(
+                f"train_loss",
+                train_loss,
+                on_step=True,
+                on_epoch=True,
+                prog_bar=True,
+                logger=True,
+                batch_size=mask.shape[0],
+                sync_dist=True,
+                add_dataloader_idx=False,
+            )
+
+            # For scaling laws
+            b, n = mask.shape
+            nflops_step = None
+            if nflops_step is not None:
+                self.nflops = (
+                    self.nflops + nflops_step * self.trainer.world_size
+                )  # Times number of processes so it logs sum across devices
+                self.log(
+                    "scaling/nflops",
+                    self.nflops * 1.0,
+                    on_step=True,
+                    on_epoch=False,
+                    prog_bar=False,
+                    logger=True,
+                    batch_size=1,
+                    sync_dist=True,
+                )
+
+            self.nsamples_processed = (
+                self.nsamples_processed + b * self.trainer.world_size
+            )
+            self.log(
+                "scaling/nsamples_processed",
+                self.nsamples_processed * 1.0,
+                on_step=True,
+                on_epoch=False,
+                prog_bar=False,
+                logger=True,
+                batch_size=1,
+                sync_dist=True,
+            )
+
+            self.log(
+                "scaling/nparams",
+                self.nparams * 1.0,
+                on_step=True,
+                on_epoch=False,
+                prog_bar=False,
+                logger=True,
+                batch_size=1,
+                sync_dist=True,
+            )
+            # Constant line but ok, easy to compare # params
+
+        return train_loss
+
+    def compute_loss_weight(
+        self, t: Float[Tensor, "*"], eps: float = 1e-3
+    ) -> Float[Tensor, "*"]:
+        t = t.clamp(min=eps, max=1.0 - eps)  # For safety
+        return t / (
+            1.0 - t
+        )
+
+    def compute_fm_loss(
+        self,
+        x_1: Float[Tensor, "* n 3"],
+        x_1_pred: Float[Tensor, "* n 3"],
+        x_t: Float[Tensor, "* n 3"],
+        t: Float[Tensor, "*"],
+        mask: Bool[Tensor, "* nres"],
+        coords_mask: Bool[Tensor, "* nresx4"],
+        log_prefix: str,
+    ) -> Float[Tensor, "*"]:
+        """
+        Computes and logs flow matching loss.
+
+        Args:
+            x_1: True clean sample, shape [*, n, 3].
+            x_1_pred: Predicted clean sample, shape [*, n, 3].
+            x_t: Sample at interpolation time t (used as input to predict clean sample), shape [*, n, 3].
+            t: Interpolation time, shape [*].
+            mask: Boolean residue mask, shape [*, nres].
+            coords_mask: Boolean residue mask, shape [*, nresx4].
+
+        Returns:
+            Flow matching loss.
+        """
+        natoms = torch.sum(coords_mask, dim=-1) * 3  # [*]
+
+        err = (x_1 - x_1_pred) * coords_mask[..., None]  # [*, n, 3]
+        loss = torch.sum(err**2, dim=(-1, -2)) / natoms  # [*]
+
+        total_loss_w = 1.0 / ((1.0 - t) ** 2 + 1e-5)
+
+        loss = loss * total_loss_w  # [*]
+        if log_prefix:
+            self.log(
+                f"{log_prefix}/trans_loss",
+                torch.mean(loss),
+                on_step=True,
+                on_epoch=True,
+                prog_bar=True,
+                logger=True,
+                batch_size=mask.shape[0],
+                sync_dist=True,
+                add_dataloader_idx=False,
+            )
+        return loss
+
+    def compute_auxiliary_loss(
+        self,
+        x_1: Float[Tensor, "* n 3"],
+        x_1_pred: Float[Tensor, "* n 3"],
+        x_t: Float[Tensor, "* n 3"],
+        t: Float[Tensor, "*"],
+        mask: Bool[Tensor, "* n"],
+        nn_out: Dict[str, Tensor],
+        log_prefix: str,
+        batch: Dict[str, Tensor] = None,
+    ) -> Float[Tensor, ""]:
+        """
+        Computes and logs auxiliary losses.
+
+        Args:
+            x_1: True clean sample, shape [*, n, 3].
+            x_1_pred: Predicted clean sample, shape [*, n, 3].
+            x_t: Sample at interpolation time t (used as input to predict clean sample), shape [*, n, 3].
+            t: Interpolation time, shape [*].
+            mask: Boolean residue mask, shape [*, n].
+            nn_out: Dictionary of output from neural network
+
+        Returns:
+            Auxiliary loss.
+        """
+        bs = x_1.shape[0]
+        n = x_1.shape[1]
+        nres = mask.sum(-1)  # [*]
+
+        gt_ca_coors = rearrange(
+            x_1,
+            "b (n c) d -> b n c d",
+            c=4
+        )[..., 1, :] * mask[..., None]  # [*, n, 3]
+        pred_ca_coors = rearrange(
+            x_1_pred,
+            "b (n c) d -> b n c d",
+            c=4
+        )[..., 1, :] * mask[..., None]  # [*, n, 3]
+        pair_mask = mask[..., None, :] * mask[..., None]  # [*, n, n]
+
+        # Pairwise distances
+        gt_pair_dists = torch.linalg.norm(
+            gt_ca_coors[:, :, None, :] - gt_ca_coors[:, None, :, :], dim=-1
+        )  # [*, n, n]
+        pred_pair_dists = torch.linalg.norm(
+            pred_ca_coors[:, :, None, :] - pred_ca_coors[:, None, :, :], dim=-1
+        )  # [*, n, n]
+        gt_pair_dists = gt_pair_dists * pair_mask  # [*, n, n]
+        pred_pair_dists = pred_pair_dists * pair_mask  # [*, n, n]
+
+        # Add mask to only account for pairs that are closer than thr in ground truth
+        max_dist = self.cfg_exp.loss.thres_aux_2d_loss
+        if max_dist is None:
+            max_dist = 1e10
+        pair_mask_thr = gt_pair_dists < max_dist  # [*, n, n]
+        total_pair_mask = pair_mask * pair_mask_thr  # [*, n, n]
+
+        # Compute loss
+        den = torch.sum(total_pair_mask, dim=(-1, -2)) - nres
+        dist_mat_loss = torch.sum(
+            (gt_pair_dists - pred_pair_dists) ** 2 * total_pair_mask, dim=(-1, -2)
+        )  # [*]
+        dist_mat_loss = dist_mat_loss / den  # [*]
+
+        # Distogram loss
+        num_dist_buckets = self.cfg_exp.loss.get("num_dist_buckets", 64)
+        pair_pred = nn_out.get("pair_pred", None)
+        if num_dist_buckets and pair_pred is not None:
+            assert (
+                num_dist_buckets == pair_pred.shape[-1]
+            ), "The number of distance buckets should be equal with the output dim of pair pred head"
+            assert num_dist_buckets > 1, "Need more than one bucket for distogram loss"
+
+            # Bucketize pair distance
+            max_dist_boundary = self.cfg_exp.loss.get("max_dist_boundary", 1.0)
+            boundaries = torch.linspace(
+                0.0, max_dist_boundary, num_dist_buckets - 1, device=pair_pred.device
+            )
+            gt_pair_dist_bucket = torch.bucketize(
+                gt_pair_dists, boundaries
+            )  # [*, n, n], each value in [0, num_dist_buckets)
+
+            # Distogram loss
+            pair_pred = pair_pred.view(bs * n * n, num_dist_buckets)
+            gt_pair_dist_bucket = gt_pair_dist_bucket.view(bs * n * n)
+            distogram_loss = torch.nn.functional.cross_entropy(
+                pair_pred, gt_pair_dist_bucket, reduction="none"
+            )  # [bs * n * n]
+            distogram_loss = distogram_loss.view(bs, n, n)
+            distogram_loss = torch.sum(distogram_loss * pair_mask, dim=(-1, -2))  # [*]
+            distogram_loss = distogram_loss / (
+                pair_mask.sum(dim=(-1, -2)) + 1e-10
+            )  # [*]
+        else:
+            distogram_loss = dist_mat_loss * 0
+
+        auxiliary_loss = (
+            distogram_loss
+            * (t > self.cfg_exp.loss.aux_loss_t_lim)
+            * self.cfg_exp.loss.aux_loss_weight
+        )
+        auxiliary_loss_no_w = distogram_loss * (t > self.cfg_exp.loss.aux_loss_t_lim)
+        motif_aux_loss_weight = self.cfg_exp.loss.get("motif_aux_loss_weight", 0)
+        scaffold_aux_loss_weight = self.cfg_exp.loss.get("scaffold_aux_loss_weight", 0)
+        if scaffold_aux_loss_weight > 0:
+            scaffold_loss = scaffold_aux_loss_weight * self.compute_fm_loss(
+                        x_1=x_1,
+                        x_1_pred=x_1_pred,
+                        x_t=x_t,
+                        mask=~batch["fixed_sequence_mask"]*batch["mask"],
+                        t=t,
+                        log_prefix=None
+                    )
+            auxiliary_loss += scaffold_loss
+            self.log(
+                f"{log_prefix}/scaffold_loss",
+                torch.mean(scaffold_loss),
+                on_step=True,
+                on_epoch=True,
+                prog_bar=False,
+                logger=True,
+                batch_size=mask.shape[0],
+                sync_dist=True,
+                add_dataloader_idx=False,
+            )
+        elif motif_aux_loss_weight:
+            mask_to_use = batch["fixed_sequence_mask"] * batch["mask"]
+            check_weight = 1.0
+            if not batch["fixed_sequence_mask"].any():
+                check_weight = 0
+                mask_to_use = batch["mask"]
+            motif_loss = motif_aux_loss_weight * self.compute_fm_loss(
+                x_1=x_1,
+                x_1_pred=x_1_pred,
+                x_t=x_t,
+                mask=mask_to_use,
+                t=t,
+                log_prefix=None,
+            )
+            auxiliary_loss += check_weight * motif_loss
+            self.log(
+                f"{log_prefix}/motif_loss",
+                torch.mean(motif_loss * check_weight),
+                on_step=True,
+                on_epoch=True,
+                prog_bar=False,
+                logger=True,
+                batch_size=mask.shape[0],
+                sync_dist=True,
+                add_dataloader_idx=False,
+            )
+
+        self.log(
+            f"{log_prefix}/distogram_loss",
+            torch.mean(distogram_loss),
+            on_step=True,
+            on_epoch=True,
+            prog_bar=False,
+            logger=True,
+            batch_size=mask.shape[0],
+            sync_dist=True,
+            add_dataloader_idx=False,
+        )
+        self.log(
+            f"{log_prefix}/dist_mat_loss",
+            torch.mean(dist_mat_loss),
+            on_step=True,
+            on_epoch=True,
+            prog_bar=False,
+            logger=True,
+            batch_size=mask.shape[0],
+            sync_dist=True,
+            add_dataloader_idx=False,
+        )
+        self.log(
+            f"{log_prefix}/auxiliary_loss",
+            torch.mean(auxiliary_loss),
+            on_step=True,
+            on_epoch=True,
+            prog_bar=False,
+            logger=True,
+            batch_size=mask.shape[0],
+            sync_dist=True,
+            add_dataloader_idx=False,
+        )
+        self.log(
+            f"{log_prefix}/auxiliary_loss_no_w",
+            torch.mean(auxiliary_loss_no_w),
+            on_step=True,
+            on_epoch=True,
+            prog_bar=False,
+            logger=True,
+            batch_size=mask.shape[0],
+            sync_dist=True,
+            add_dataloader_idx=False,
+        )
+        return auxiliary_loss
+
+    def detach_gradients(self, x):
+        """Detaches gradients from sample x"""
+        return x.detach()
+
+    def samples_to_atom37(self, samples):
+        """
+        Transforms samples to atom37 representation.
+
+        Args:
+            samples: Tensor of shape [b, n, 3]
+
+        Returns:
+            Samples in atom37 representation, shape [b, n, 37, 3].
+        """
+        return trans_nm_to_atom37(samples, ca_only=False)  # [b, n, 37, 3]

--- a/proteinfoundation/train_bb.py
+++ b/proteinfoundation/train_bb.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+import os
+import sys
+
+root = os.path.abspath(".")
+sys.path.append(root)  # Adds project's root directory
+
+import argparse
+import json
+import pickle
+from pathlib import Path
+
+import hydra
+import lightning as L
+import loralib as lora
+import torch
+import wandb
+from dotenv import load_dotenv
+from lightning.pytorch.loggers import WandbLogger
+from lightning.pytorch.utilities import rank_zero_only
+from loguru import logger
+from omegaconf import OmegaConf
+
+from proteinfoundation.proteinflow.proteinb import Proteinb
+from proteinfoundation.utils.ema_utils.ema_callback import EMA, EmaModelCheckpoint
+from proteinfoundation.utils.fetch_last_ckpt import fetch_last_ckpt
+from proteinfoundation.utils.lora_utils import replace_lora_layers
+from proteinfoundation.utils.metric_utils import (
+    transform_global_percentage_to_mask_dropout,
+)
+from proteinfoundation.utils.seed_callback import SeedCallback
+from proteinfoundation.utils.training_analysis_utils import (
+    GradAndWeightAnalysisCallback,
+    LogEpochTimeCallback,
+    LogSetpTimeCallback,
+    SkipNanGradCallback,
+)
+
+
+# Things that should only be done by a single process
+@rank_zero_only
+def log_info(msg):
+    logger.info(msg)
+
+
+@rank_zero_only
+def store_configs(path_configs):
+    for cfg, path in path_configs:
+        with open(path, "w") as f:
+            cfg_aux = OmegaConf.to_container(cfg, resolve=True)
+            json.dump(cfg_aux, f, indent=4, sort_keys=True)
+
+
+@rank_zero_only
+def log_configs(path_configs, wandb_logger):
+    if wandb_logger is None:
+        return
+    artifact = wandb.Artifact(f"config_files_{run_name}", type="config")
+    for _, path in path_configs:
+        artifact.add_file(path)
+    wandb_logger.experiment.log_artifact(artifact)
+
+
+@rank_zero_only
+def create_dir(checkpoint_path_store, parents=True, exist_ok=True):
+    Path(checkpoint_path_store).mkdir(parents=parents, exist_ok=exist_ok)
+
+
+if __name__ == "__main__":
+
+    load_dotenv()
+
+    parser = argparse.ArgumentParser(description="Job info")
+    parser.add_argument(
+        "--config_name",
+        type=str,
+        default="training_ca",
+        help="Name of the config yaml file.",
+    )
+    parser.add_argument(
+        "--nolog",
+        action="store_true",
+        help="Avoids checkpoints and wandb logging, mostly for debugging.",
+    )
+    parser.add_argument(
+        "--single", action="store_true", help="Sets single node and single GPU, ignoring config file."
+    )
+    parser.add_argument(
+        "--show_prog_bar",
+        action="store_true",
+        help="Shows progress bar as training progresses.",
+    )
+    args = parser.parse_args()
+
+    logger.add(
+        sys.stdout,
+        format="{time:YYYY-MM-DD HH:mm:ss} | {level} | {file}:{line} | {message}",
+    )  # Send to stdout
+    log_info(f"Avoid wandb and checkpointing: {args.nolog}")
+    callbacks = [SeedCallback()]  # Different devices will be assigend different seeds
+
+    # Load experiment config
+    config_path = "../configs/experiment_config"
+    with hydra.initialize(config_path, version_base=hydra.__version__):
+        cfg_exp = hydra.compose(config_name=args.config_name)
+        if args.single:
+            # Rewrite number of GPUs and nodes for local runs or if single flag is used
+            cfg_exp.hardware.ngpus_per_node_ = 1
+            cfg_exp.hardware.nnodes_ = 1
+            cfg_exp.run_name_ = cfg_exp.run_name_ + "_single"
+        log_info(f"Exp config {cfg_exp}")
+
+    # Set training precision
+    precision = "32"
+    if not cfg_exp.force_precision_f32:
+        log_info("Using mixed precision")
+        torch.set_float32_matmul_precision("medium")
+        # precision = "16"
+        precision = "bf16-mixed"
+
+    # Set training fold labels dropout rate based on global percentage
+    if cfg_exp.training.get("fold_label_sample_ratio") is not None:
+        log_info("Setting fold label dropout rate based on fold_label_sample_ratio")
+        (
+            cfg_exp.training.mask_T_prob,
+            cfg_exp.training.mask_A_prob,
+            cfg_exp.training.mask_C_prob,
+        ) = transform_global_percentage_to_mask_dropout(
+            cfg_exp.training.fold_label_sample_ratio
+        )
+        log_info(
+            "Set mask_T_prob: %.3f, mask_A_prob: %.3f, mask_C_prob: %.3f"
+            % (
+                cfg_exp.training.mask_T_prob,
+                cfg_exp.training.mask_A_prob,
+                cfg_exp.training.mask_C_prob,
+            )
+        )
+
+    # Set run name and root directory for the run, used to store things
+    run_name = cfg_exp.run_name_
+    log_info(f"Job name: {run_name}")
+    root_run = os.path.join(
+        ".", "store", run_name
+    )  # Everything stored in ./store/<run_id>
+    log_info(f"Root run: {root_run}")
+
+    # Set checkpoint directory
+    checkpoint_path_store = os.path.join(
+        root_run, "checkpoints"
+    )  # Checkpoints in ./store/run_id/checkpoints/<ckpt-file>
+    log_info(f"Checkpoints directory: {checkpoint_path_store}")
+
+    # Check if last checkpoint exists (this is useful if interrupted, it starts from last checkpoint)
+    last_ckpt_name = fetch_last_ckpt(checkpoint_path_store)
+    last_ckpt_path = (
+        os.path.join(checkpoint_path_store, last_ckpt_name)
+        if last_ckpt_name is not None
+        else None
+    )
+    log_info(f"Last checkpoint: {last_ckpt_path}")
+
+    # Extract number of cpus from config file
+    num_cpus = cfg_exp.hardware.ncpus_per_task_train_
+    log_info(
+        f"Number of CPUs per task used (will be used for number dataloader number of workers): {num_cpus}"
+    )
+
+    # If no checkpoint set seed for correct initialization
+    if last_ckpt_path is None:
+        log_info(f"Seeding everything to seed {cfg_exp.seed}")
+        L.seed_everything(cfg_exp.seed)
+
+    # Load data config
+    dataset_config_subdir = cfg_exp.get("dataset_config_subdir", None)
+    if dataset_config_subdir is not None:
+        # if args.dataset_config_subdir:
+        config_path = f"../configs/datasets_config/{dataset_config_subdir}"
+    else:
+        config_path = "../configs/datasets_config/"
+    with hydra.initialize(config_path, version_base=hydra.__version__):
+        cfg_data = hydra.compose(config_name=cfg_exp["dataset"])
+        cfg_data.datamodule.num_workers = num_cpus  # Overwrite number of cpus
+        if cfg_data.get("exclude_id_pkl_path") is not None:
+            with open(cfg_data.exclude_id_pkl_path, "rb") as fin:
+                exclude_ids = pickle.load(fin)
+            if cfg_data.datamodule.dataselector.exclude_ids is not None:
+                cfg_data.datamodule.dataselector.exclude_ids += exclude_ids
+            else:
+                cfg_data.datamodule.dataselector.exclude_ids = exclude_ids
+        log_info(f"Data config {cfg_data}")
+
+    # create datamodule containing default train and val dataloader
+    datamodule = hydra.utils.instantiate(cfg_data.datamodule)
+
+    # Set logger
+    wandb_logger = None
+    if cfg_exp.log.log_wandb and not args.nolog:
+        wandb_logger = WandbLogger(project=cfg_exp.log.wandb_project, name=run_name)
+        # callbacks.append(LogEpochTimeCallback())
+        callbacks.append(LogSetpTimeCallback())
+
+    log_info(f"Using EMA with decay {cfg_exp.ema.decay}")
+    callbacks.append(EMA(**cfg_exp.ema))
+
+    # Set checkpointing
+    if cfg_exp.log.checkpoint and not args.nolog:
+        args_ckpt_last = {
+            "dirpath": checkpoint_path_store,
+            "save_weights_only": False,
+            "filename": "ignore",
+            "every_n_train_steps": cfg_exp.log.last_ckpt_every_n_steps,
+            "save_last": True,
+        }
+        args_ckpt = {
+            "dirpath": checkpoint_path_store,
+            "save_last": False,
+            "save_weights_only": False,
+            "filename": "chk_{epoch:08d}_{step:012d}",
+            "every_n_train_steps": cfg_exp.log.checkpoint_every_n_steps,
+            "monitor": "train/trans_loss",
+            "save_top_k": 10000,
+            "mode": "min",
+        }
+        checkpoint_callback = EmaModelCheckpoint(**args_ckpt)
+        checkpoint_callback_last = EmaModelCheckpoint(**args_ckpt_last)
+
+        create_dir(checkpoint_path_store, parents=True, exist_ok=True)
+        callbacks.append(checkpoint_callback)
+        callbacks.append(checkpoint_callback_last)
+
+        # Save and log config files
+        path_configs = [
+            (
+                cfg_data,
+                os.path.join(checkpoint_path_store, f"data_config_{run_name}.json"),
+            ),
+            (
+                cfg_exp,
+                os.path.join(checkpoint_path_store, f"exp_config_{run_name}.json"),
+            ),
+        ]
+        store_configs(path_configs)
+        log_configs(path_configs, wandb_logger)
+
+    # Gradient and weight stats thoughout training, possibly skip updates with nan in grad
+    if cfg_exp.opt.grad_and_weight_analysis:
+        callbacks.append(GradAndWeightAnalysisCallback())
+    if cfg_exp.opt.skip_nan_grad:
+        callbacks.append(SkipNanGradCallback())
+
+    # Define model
+    model = Proteinb(cfg_exp, store_dir=root_run)
+
+    # If LoRA is tunred on, replace Linear with LoRA layers
+    if cfg_exp.get("lora") and cfg_exp.lora.get("r"):
+        replace_lora_layers(
+            model, cfg_exp.lora.r, cfg_exp.lora.lora_alpha, cfg_exp.lora.lora_dropout
+        )
+        lora.mark_only_lora_as_trainable(model, bias=cfg_exp.lora.train_bias)
+
+    # If this is the first run for fine-tuning, load pre-trained checkpoint and don't load optimizer states
+    pretrain_ckpt_path = cfg_exp.get("pretrain_ckpt_path", None)
+    if last_ckpt_path is None and pretrain_ckpt_path is not None:
+        log_info(f"Loading from pre-trained checkpoint path {pretrain_ckpt_path}")
+        ckpt = torch.load(pretrain_ckpt_path, map_location="cpu")
+        model.load_state_dict(ckpt["state_dict"], strict=False)
+
+    # Train
+    plugins = []
+    show_prog_bar = args.show_prog_bar
+    trainer = L.Trainer(
+        max_epochs=cfg_exp.opt.max_epochs,
+        accelerator=cfg_exp.hardware.accelerator,
+        devices=cfg_exp.hardware.ngpus_per_node_,  # This is number of gpus per node, not total
+        num_nodes=cfg_exp.hardware.nnodes_,
+        callbacks=callbacks,
+        logger=wandb_logger,
+        log_every_n_steps=cfg_exp.opt.log_every_n_steps,
+        default_root_dir=root_run,
+        check_val_every_n_epoch=None,  # Leave like this
+        val_check_interval=cfg_exp.opt.val_check_interval,
+        strategy=cfg_exp.opt.dist_strategy,
+        enable_progress_bar=show_prog_bar,
+        plugins=plugins,
+        accumulate_grad_batches=cfg_exp.opt.accumulate_grad_batches,
+        num_sanity_val_steps=1,
+        precision=precision,
+        gradient_clip_algorithm="norm",
+        gradient_clip_val=1.0,
+    )
+    trainer.fit(
+        model, datamodule, ckpt_path=last_ckpt_path
+    )  # If None then it starts from scratch


### PR DESCRIPTION
### Overview

This PR **upgrades Proteina's atom modeling** from solely C-alpha (CA) to **all backbone atoms (N, CA, C, O)**, providing a more comprehensive and accurate protein representation.

-----

### Key Changes

1.  **New `All-Atom` Module:** Integrated into `protein_transformer` for expanded atom processing.
2.  **`Local Atom Attention`:** Added to `attention_pair_bias` to model fine-grained local atom structures.
3.  **Adapted Input/Output Shape and Masking:** Reshaped `x` to `[b, nres*4, 3]` and introduced `coords_mask [b, nres*4]` for individual atom validity.
4.  **`r3n_fm` Refactoring:** Modified for compatibility with new `x` shape and `coords_mask`.
5. **Others**: Some changes to obtain a clean output.

-----

### Testing

  * **Training Pipeline:** Successfully ran on 8 H100 GPUs (`60M_notri` version) without errors.
    <img width="1170" alt="image" src="https://github.com/user-attachments/assets/328e53ad-b232-45cd-a90f-937272c4ca79" />
  * **Unconditional Generation:** Produced structurally sound and plausible backbone conformations.
    Updated training and inference configurations are included for reproducibility.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/384656da-cbee-45c1-97ae-8f3cb839abdf" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/bcb97ccc-3449-4509-bc67-56057fd28c82" />
